### PR TITLE
Issue/70 Add English conventions to GitHub (from Wiki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An open-source open-world multiplayer hacking game.
 
 ## What is it?
 
-Cryptic is a deep strategy game. The goal of this deep strategy game is to hack other players and think creatively like real hackers. You only start with a virtual computer and a few crypto coins. You must think carefully about your actions before attacking another player and learn the basics of the game. But it's not hard to get started.  
+Cryptic is a deep strategy game. Its goal is to hack other players and think creatively like real hackers. You only start with a virtual computer and a few crypto coins. You must think carefully about your actions before attacking another player and learn the basics of the game. But it's not hard to get started.  
 
 ## How to play the game?
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Cryptic is driven by a non-profit-oriented team that maintains the game, adds ne
 
 Anything from design to development will be helpful, no matter what skills you have. For more information, talk to us on Discord or send us an email.
 
+Note: There are some [Github/coding/naming conventions](conventions.md) specific to the Cryptic project.
+
 ## Project Structure
 
 ![project structure](https://raw.githubusercontent.com/cryptic-game/graphics/master/wallpaper/ablauf.png)

--- a/conventions.md
+++ b/conventions.md
@@ -1,3 +1,53 @@
 # Cryptic Conventions
-You can find the conventions in our official Wiki:
-- [Konventionen (Deutsch)](https://wiki.cryptic-game.net/books/einf%C3%BChrungen/page/konventionen)
+
+Follow these global conventions for [Cryptic](https://github.com/cryptic-game) to ensure a clear and uniform style. 
+
+In general, please use English for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc).
+
+## Branches
+
+- **master**: Contains the actual version. New commits are only added via pull request merges.
+- **issue/\<id\>-\<name\>**: Feature branches contain one or more commits to address the related issue (e.g. `issue/42-add-foo-bar`).
+- **dependencies/\<dependencies-name\>**: Branches to update dependencies. 
+
+Any submitted pull request requires two approvals (from Quality Management and the department's Head (Assistant).
+
+## Templates (issues/pull requests)
+
+- [Bug Report](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md)
+- [Feature Request](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md)
+- [Pull Request Template](https://github.com/cryptic-game/cryptic/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
+
+Some notes for issues and pull requests:  
+
+- **Issue/Pull Request title**: Shortly summarizes the content. Avoid special characters.
+- **Issue/ Pull Request content**: Adds more information for the issue/pull request. Fill out all fields predefined by the issue template. In pull requests, add an issue id/link.
+- **Commit Messages**: Use the scheme `<message> (#<issue-id>)`. Use English for the message. The message must be short (< 50 characters) and contain useful text. Do not use just `<em>bug fix</em>`.Execeptions are hotfixes and merge commits.
+- **Merge Commits**: For commits from a feature branch into master, use the merge option, not squash or rebase. 
+- **Merge Conflicts**: Fix any merge conflicts in a feature branch (which can appear when you want to merge into master) by merging master into your feature branch. The commit message should be named `Solved merge conflicts for #<pull-request-id>`.
+
+## Release Versioning / Hotfixes
+
+For releases, we follow [Semantic Versioning 2.0.0](https://semver.org/).
+
+Head (Asistants) can create/approve hotfixes for severe/security-related issues to address quick fixes. Such commits should use the naming scheme: `Hotfix: <message>` (z.B. `Hotfix: Changed foo bar`). Create a new branch from a release-tag and name the new release as `<old-release-name>.x` - each hotfix for a release increases x by 1, e.g. `v0.3.1-pre-alpha.2`.
+
+## Code Style
+
+- Java: Follow the general [Java Code Conventions](https://www.oracle.com/technetwork/java/codeconventions-150003.pdf)
+- Python: Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) with some exceptions:
+    - As Autoformatter, use [PyCharm](https://www.jetbrains.com/pycharm/) (preferred) or [black](https://github.com/python/black).
+    - Max line length: 120 characters. 
+    - Remove unnecessary blank lines but keep one blank line at the end of each file.
+    - Use typing except for obvious types (e.g. `foo = "bar"`)
+- Angular: Follow the [Angular Coding Style Guide](https://angular.io/guide/styleguide). 
+
+Naming conventions for variables and functions:  
+
+Follow [grammar based naming conventions](https://dev.to/somedood/a-grammar-based-naming-convention-13jf) with some exceptions: 
+- Name functions using *snake\_case*
+- Do not use the *is-* prefix for *bool* typed variables. 
+
+Add any exceptions with `# noinspection PyPep8Naming` and a comment. <!-- check and change if required -->If classes are saved as variable, e.g. `self.Session: sessionmaker = sessionmaker(...)`.
+
+We recommend WebStorm (free for pupils and students) or Visual Studio Code as development environment. Additionally, use [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) and [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig). For Webstorm, use [Karma](https://plugins.jetbrains.com/plugin/7287-karma).

--- a/conventions.md
+++ b/conventions.md
@@ -30,7 +30,7 @@ Some notes for issues and pull requests:
 
 For releases, we follow [Semantic Versioning 2.0.0](https://semver.org/).
 
-Head (Asistants) can create/approve hotfixes for severe/security-related issues to address quick fixes. Such commits should use the naming scheme: `Hotfix: <message>` (z.B. `Hotfix: Changed foo bar`). Create a new branch from a release-tag and name the new release as `<old-release-name>.x` - each hotfix for a release increases x by 1, e.g. `v0.3.1-pre-alpha.2`.
+Heads (or Head Asistants) can create/approve hotfixes for severe/security-related issues to address quick fixes. Such commits should use the naming scheme: `Hotfix: <message>` (z.B. `Hotfix: Changed foo bar`). Create a new branch from a release-tag and name the new release as `<old-release-name>.x` - each hotfix for a release increases x by 1, e.g. `v0.3.1-pre-alpha.2`.
 
 ## Code Style
 

--- a/conventions.md
+++ b/conventions.md
@@ -50,4 +50,4 @@ Follow [grammar based naming conventions](https://dev.to/somedood/a-grammar-base
 
 Add any exceptions with `# noinspection PyPep8Naming` and a comment. <!-- check and change if required -->If classes are saved as variable, e.g. `self.Session: sessionmaker = sessionmaker(...)`.
 
-We recommend WebStorm (free for pupils and students) or Visual Studio Code as development environment. Additionally, use [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) and [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig). For Webstorm, use [Karma](https://plugins.jetbrains.com/plugin/7287-karma).
+We recommend [WebStorm ](https://www.jetbrains.com/webstorm/) (free for pupils/students) or [Visual Studio Code](https://code.visualstudio.com/) as development environment. Additionally, use [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) and [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig). For Webstorm, use [Karma](https://plugins.jetbrains.com/plugin/7287-karma).

--- a/conventions.md
+++ b/conventions.md
@@ -45,7 +45,7 @@ Heads (or Head Asistants) can create/approve hotfixes for severe/security-relate
 Naming conventions for variables and functions:  
 
 Follow [grammar based naming conventions](https://dev.to/somedood/a-grammar-based-naming-convention-13jf) with some exceptions: 
-- Name functions using *snake\_case*
+- Name functions using *snake\_case*.
 - Do not use the *is-* prefix for *bool* typed variables. 
 
 Add any exceptions with `# noinspection PyPep8Naming` and a comment. <!-- check and change if required -->If classes are saved as variable, e.g. `self.Session: sessionmaker = sessionmaker(...)`.

--- a/conventions.md
+++ b/conventions.md
@@ -39,7 +39,7 @@ Heads (or Head Asistants) can create/approve hotfixes for severe/security-relate
     - As Autoformatter, use [PyCharm](https://www.jetbrains.com/pycharm/) (preferred) or [black](https://github.com/python/black).
     - Max line length: 120 characters. 
     - Remove unnecessary blank lines but keep one blank line at the end of each file.
-    - Use typing except for obvious types (e.g. `foo = "bar"`)
+    - Use typing except for obvious types (e.g. `foo = "bar"`).
 - Angular: Follow the [Angular Coding Style Guide](https://angular.io/guide/styleguide). 
 
 Naming conventions for variables and functions:  

--- a/conventions.md
+++ b/conventions.md
@@ -10,9 +10,11 @@ The master (or main) branch contains the actual version. New commits to are only
 
 ## Commit Messages
 
-Write short (< 50 characters) **commit messages** in English and use the scheme `<message> (#<issue-id>)`. Do not use just `<em>bug fix</em>` but useful text. Hotfixes and merge commits.
+Write short (< 50 characters) **commit messages** in English and use the scheme `<message> (#<issue-id>)`. Do not use just `<em>bug fix</em>` but useful text.
 
 The commit message that fixes any merge conflicts in your feature branch (after you have merged master into your branch) should be `Solved merge conflicts for #<pull-request-id>`.
+
+<!-- special hotfix commit msg? -->
 
 ### Merging Branches
 

--- a/conventions.md
+++ b/conventions.md
@@ -1,52 +1,55 @@
 # Cryptic Conventions
 
-Follow these conventions to ensure a clear and uniform style. 
+ Please use English for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc) and follow the conventions below to ensure a clear and uniform style.
 
-In general, please use English for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc).
+## Branch Naming
 
-## Branches
+The master (or main) branch contains the actual version. New commits to are only added via pull requests which requires two approvals. Learn more about [GitHub branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
-- **master**: Contains the actual version. New commits are only added via pull request merges.
-- **issue/\<id\>-\<name\>**: Feature branches contain one or more commits to address the related issue (e.g. `issue/42-add-foo-bar`).
-- **dependencies/\<dependencies-name\>**: Branches to update dependencies. 
+**Feature branches** contain one or more commits to address one related feature or issue. Prefix your feature branch with `issue/issue-id` before you add the actual branch name. Example: `issue/\<id\>-\<add-my-feature\>`. To update any project dependencies, name your branch like `dependencies/\<dependencies-name\>`.
 
-Any submitted pull request requires two approvals (from Quality Management and the department's Head (Assistant).
+## Commit Messages
 
-## Templates (issues/pull requests)
+Write short (< 50 characters) **commit messages** in English and use the scheme `<message> (#<issue-id>)`. Do not use just `<em>bug fix</em>` but useful text. Hotfixes and merge commits.
+
+The commit message that fixes any merge conflicts in your feature branch (after you have merged master into your branch) should be `Solved merge conflicts for #<pull-request-id>`.
+
+### Merging Branches
+
+To merge a feature branch into master, use the option **merge** (not squash or rebase) to create a merge commit.
+
+## Issues and Pull Requests
+
+- **Title**: Shortly summarize the content but avoid special characters.
+- **Content/Description**: Add more information to the issue or pull request.
+
+When submitting an issue or pull request, fill out all other information requested in these predefined templates:
 
 - [Bug Report](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md)
 - [Feature Request](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md)
 - [Pull Request Template](https://github.com/cryptic-game/cryptic/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
 
-Some notes for issues and pull requests:  
-
-- **Issue/Pull Request title**: Shortly summarizes the content. Avoid special characters.
-- **Issue/ Pull Request content**: Adds more information for the issue/pull request. Fill out all fields predefined by the issue template. In pull requests, add an issue id/link.
-- **Commit Messages**: Use the scheme `<message> (#<issue-id>)`. Use English for the message. The message must be short (< 50 characters) and contain useful text. Do not use just `<em>bug fix</em>`.Execeptions are hotfixes and merge commits.
-- **Merge Commits**: For commits from a feature branch into master, use the merge option, not squash or rebase. 
-- **Merge Conflicts**: Fix any merge conflicts in a feature branch (which can appear when you want to merge into master) by merging master into your feature branch. The commit message should be named `Solved merge conflicts for #<pull-request-id>`.
-
 ## Release Versioning / Hotfixes
 
 For releases, we follow [Semantic Versioning 2.0.0](https://semver.org/).
 
-Heads (or Head Asistants) can create/approve hotfixes for severe/security-related issues to address quick fixes. Such commits should use the naming scheme: `Hotfix: <message>` (z.B. `Hotfix: Changed foo bar`). Create a new branch from a release-tag and name the new release as `<old-release-name>.x` - each hotfix for a release increases x by 1, e.g. `v0.3.1-pre-alpha.2`.
+Heads (or Head Assistants) can create/approve hotfixes for severe/security-related issues to address quick fixes. Such commits should use the naming scheme: `Hotfix: <message>` (z.B. `Hotfix: Changed foo bar`). Create a new branch from a release-tag and name the new release as `<old-release-name>.x` - each hotfix for a release increases x by 1, e.g. `v0.3.1-pre-alpha.2`.
 
 ## Code Style
 
 - Java: Follow the general [Java Code Conventions](https://www.oracle.com/technetwork/java/codeconventions-150003.pdf)
 - Python: Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/) with some exceptions:
     - As Autoformatter, use [PyCharm](https://www.jetbrains.com/pycharm/) (preferred) or [black](https://github.com/python/black).
-    - Max line length: 120 characters. 
+    - Max line length: 120 characters.
     - Remove unnecessary blank lines but keep one blank line at the end of each file.
     - Use typing except for obvious types (e.g. `foo = "bar"`).
-- Angular: Follow the [Angular Coding Style Guide](https://angular.io/guide/styleguide). 
+- Angular: Follow the [Angular Coding Style Guide](https://angular.io/guide/styleguide).
 
-Naming conventions for variables and functions:  
+### Naming variables and functions
 
-Follow [grammar based naming conventions](https://dev.to/somedood/a-grammar-based-naming-convention-13jf) with some exceptions: 
+Follow [grammar based naming conventions](https://dev.to/somedood/a-grammar-based-naming-convention-13jf) with some exceptions:
 - Name functions using *snake\_case*.
-- Do not use the *is-* prefix for *bool* typed variables. 
+- Do not use the *is-* prefix for *bool* typed variables.
 
 Add any exceptions with `# noinspection PyPep8Naming` and a comment. <!-- check and change if required -->If classes are saved as variable, e.g. `self.Session: sessionmaker = sessionmaker(...)`.
 

--- a/conventions.md
+++ b/conventions.md
@@ -1,12 +1,18 @@
 # Cryptic Conventions
 
- Please use English for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc) and follow the conventions below to ensure a clear and uniform style.
+Please follow the conventions below to ensure a clear and uniform style.
+
+## Language
+
+Use **English** for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc).
 
 ## Branch Naming
 
-The master (or main) branch contains the actual version. New commits to are only added via pull requests which requires two approvals. Learn more about [GitHub branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Use pull requests to add new commits to master (main) [branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) that contains the actual version. Pull requests require two approvals. 
 
-**Feature branches** contain one or more commits to address one related feature or issue. Prefix your feature branch with `issue/issue-id` before you add the actual branch name. Example: `issue/\<id\>-\<add-my-feature\>`. To update any project dependencies, name your branch like `dependencies/\<dependencies-name\>`.
+### Feature branches
+
+Feature branches contain one or more commits to address one related feature/issue. Prefix your feature branch with `issue/issue-id` before you add the actual branch name. Example: `issue/\<id\>-\<add-my-feature\>`. To update any project dependencies, name your branch like `dependencies/\<dependencies-name\>`.
 
 ## Commit Messages
 

--- a/conventions.md
+++ b/conventions.md
@@ -1,6 +1,6 @@
 # Cryptic Conventions
 
-Follow these global conventions for [Cryptic](https://github.com/cryptic-game) to ensure a clear and uniform style. 
+Follow these conventions to ensure a clear and uniform style. 
 
 In general, please use English for all Cryptic-related GitHub posts (in issues, pull requests, commits, etc).
 

--- a/conventions.md
+++ b/conventions.md
@@ -8,7 +8,7 @@ Use **English** for all Cryptic-related GitHub posts (in issues, pull requests, 
 
 ## Branch Naming
 
-Use pull requests to add new commits to master (main) [branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) that contains the actual version. Pull requests require two approvals. 
+Use pull requests to add new commits to master (main) [branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) that contains the actual version. 
 
 ### Feature branches
 
@@ -28,14 +28,13 @@ To merge a feature branch into master, use the option **merge** (not squash or r
 
 ## Issues and Pull Requests
 
+The most important information in issue and pull requests are:  
+
 - **Title**: Shortly summarize the content but avoid special characters.
 - **Content/Description**: Add more information to the issue or pull request.
 
-When submitting an issue or pull request, fill out all other information requested in these predefined templates:
+When submitting an issue or pull request, fill out all other information requested in the predefined templates provided. Pull requests require two approvals. 
 
-- [Bug Report](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md)
-- [Feature Request](https://github.com/cryptic-game/cryptic/blob/master/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md)
-- [Pull Request Template](https://github.com/cryptic-game/cryptic/blob/master/.github/PULL_REQUEST_TEMPLATE.md)
 
 ## Release Versioning / Hotfixes
 


### PR DESCRIPTION
**Description**

As the conventions are strongly related to the GitHub content, I guess it makes sense to have them in Github. I reworked the [DE conventions from the wiki](https://wiki.cryptic-game.net/books/einf%C3%BChrungen/page/konventionen) currently linked in the conventions.md file and added them to the Github page. 



As I was unsure in some parts, there might be more changes required.

**Issue**
Closes https://github.com/cryptic-game/cryptic/issues/69

**Testing Instructions**
1. Visit https://github.com/cadamini/cryptic/blob/issue/70-add-conventions/conventions.md and read the text.
2. Visit https://github.com/cadamini/cryptic/blob/issue/70-add-conventions/README.md#support-our-team and test the link to the conventions file.

**Additional Notes/Todos:**

- [x] Finalize conventions.md rework 
- [x] Link from readme.

I'd suggest having a review that potentially results in edits or additions. Some points were unclear.

- [ ] Optional: Remove wiki page or link to Github (I have no access)